### PR TITLE
Add size limit

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -34,6 +34,8 @@ class DocumentsController < ApplicationController
   def update
     document.update!(update_params)
     render json: document, serializer: SERIALIZER
+  rescue Document::OverSizeLimit => e
+    render json: { error: e.message }, status: :bad_request
   rescue ActiveRecord::RecordInvalid
     # TODO(test)
     head :bad_request

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -20,7 +20,7 @@ class Document < ActiveRecord::Base
   # since URLs show up in logs and can't be rolled back if leaked.
   TOKEN_LENGTH = 10
 
-  MAX_CONTENTS_SIZE_BYTES = 30.kilobytes
+  MAX_CONTENTS_SIZE_BYTES = 100.kilobytes
 
   def create_unique_identifier
     begin

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -18,9 +18,7 @@ class Document < ActiveRecord::Base
   # since URLs show up in logs and can't be rolled back if leaked.
   TOKEN_LENGTH = 10
 
-  # Maximum size for document contents (in bytes of JSON)
-  # Set to 1MB by default - adjust as needed
-  MAX_CONTENTS_SIZE = 1.megabyte
+  MAX_CONTENTS_SIZE_BYTES = 30.kilobytes
 
   def create_unique_identifier
     begin
@@ -49,9 +47,9 @@ class Document < ActiveRecord::Base
     contents_json = contents.to_json
     size_in_bytes = contents_json.bytesize
 
-    if size_in_bytes > MAX_CONTENTS_SIZE
+    if size_in_bytes > MAX_CONTENTS_SIZE_BYTES
       size_in_mb = (size_in_bytes.to_f / 1.megabyte).round(2)
-      limit_in_mb = (MAX_CONTENTS_SIZE.to_f / 1.megabyte).round(2)
+      limit_in_mb = (MAX_CONTENTS_SIZE_BYTES.to_f / 1.megabyte).round(2)
       errors.add(:contents, "is too large (#{size_in_mb}MB). Maximum size is #{limit_in_mb}MB")
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -49,8 +49,8 @@ class Document < ActiveRecord::Base
     size_in_bytes = original_contents.bytesize
 
     if size_in_bytes > MAX_CONTENTS_SIZE_BYTES
-      size_in_kb = (size_in_bytes.to_f / 1.kilobyte).round(2)
-      limit_in_kb = (MAX_CONTENTS_SIZE_BYTES.to_f / 1.kilobyte).round(2)
+      size_in_kb = (size_in_bytes.to_f / 1.kilobyte).ceil
+      limit_in_kb = (MAX_CONTENTS_SIZE_BYTES.to_f / 1.kilobyte).round
       raise OverSizeLimit, "Document is too large (#{size_in_kb} KB). Maximum size is #{limit_in_kb} KB."
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,4 +1,6 @@
 class Document < ActiveRecord::Base
+  class OverSizeLimit < StandardError; end
+
   before_validation :create_unique_identifier, on: :create
 
   validate :contents_must_match_schema
@@ -48,9 +50,9 @@ class Document < ActiveRecord::Base
     size_in_bytes = contents_json.bytesize
 
     if size_in_bytes > MAX_CONTENTS_SIZE_BYTES
-      size_in_mb = (size_in_bytes.to_f / 1.megabyte).round(2)
-      limit_in_mb = (MAX_CONTENTS_SIZE_BYTES.to_f / 1.megabyte).round(2)
-      errors.add(:contents, "is too large (#{size_in_mb}MB). Maximum size is #{limit_in_mb}MB")
+      size_in_kb = (size_in_bytes.to_f / 1.kilobyte).round(2)
+      limit_in_kb = (MAX_CONTENTS_SIZE_BYTES.to_f / 1.kilobyte).round(2)
+      raise OverSizeLimit, "Document is too large (#{size_in_kb} KB). Maximum size is #{limit_in_kb} KB."
     end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -44,10 +44,9 @@ class Document < ActiveRecord::Base
   end
 
   def contents_size_within_limit
-    return if contents.nil?
+    return if original_contents.nil?
 
-    contents_json = contents.to_json
-    size_in_bytes = contents_json.bytesize
+    size_in_bytes = original_contents.bytesize
 
     if size_in_bytes > MAX_CONTENTS_SIZE_BYTES
       size_in_kb = (size_in_bytes.to_f / 1.kilobyte).round(2)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,6 +2,7 @@ class Document < ActiveRecord::Base
   before_validation :create_unique_identifier, on: :create
 
   validate :contents_must_match_schema
+  validate :contents_size_within_limit, if: :contents_changed?, on: :update
   validates :token, presence: true, uniqueness: true
 
   belongs_to :user, optional: true
@@ -16,6 +17,10 @@ class Document < ActiveRecord::Base
   # But it's ok for now. Token-based security is only so strong anyway,
   # since URLs show up in logs and can't be rolled back if leaked.
   TOKEN_LENGTH = 10
+
+  # Maximum size for document contents (in bytes of JSON)
+  # Set to 1MB by default - adjust as needed
+  MAX_CONTENTS_SIZE = 1.megabyte
 
   def create_unique_identifier
     begin
@@ -35,6 +40,19 @@ class Document < ActiveRecord::Base
         schema != [] &&
         !JSON::Validator.validate(schema, contents)
       errors.add(:contents, "does not match schema")
+    end
+  end
+
+  def contents_size_within_limit
+    return if contents.nil?
+
+    contents_json = contents.to_json
+    size_in_bytes = contents_json.bytesize
+
+    if size_in_bytes > MAX_CONTENTS_SIZE
+      size_in_mb = (size_in_bytes.to_f / 1.megabyte).round(2)
+      limit_in_mb = (MAX_CONTENTS_SIZE.to_f / 1.megabyte).round(2)
+      errors.add(:contents, "is too large (#{size_in_mb}MB). Maximum size is #{limit_in_mb}MB")
     end
   end
 end

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -6,6 +6,7 @@ class DocumentSerializer < DocumentIndexSerializer
   attributes :api_url,
     :contents,
     :example_subproperty_url,
+    :max_contents_size,
     :original_contents,
     :original_schema,
     :owned_by_current_user,
@@ -13,6 +14,10 @@ class DocumentSerializer < DocumentIndexSerializer
 
   def api_url
     url_for(controller: 'api/documents', subdomain: 'api', action: 'show', token: object.token)
+  end
+
+  def max_contents_size
+    Document::MAX_CONTENTS_SIZE_BYTES
   end
 
   def example_subproperty_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,17 @@ module Npoint
         resource '*', :headers => :any, :methods => [:get, :post, :options]
       end
     end
+
+    # Rails console helpers
+    console do
+      # Look up document by token: `token 'abc'`
+      module ConsoleHelpers
+        def token(token_str)
+          Document.find_by!(token: token_str)
+        end
+      end
+
+      TOPLEVEL_BINDING.eval('self').extend(ConsoleHelpers)
+    end
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Document do
 
     context 'document size limits' do
       let(:small_contents) { { 'data' => 'small' } }
-      let(:large_contents) { { 'data' => 'x' * (Document::MAX_CONTENTS_SIZE + 1000) } }
+      let(:large_contents) { { 'data' => 'x' * (Document::MAX_CONTENTS_SIZE_BYTES + 1000) } }
       let(:schema) { nil }
 
       context 'when contents are under the limit' do
@@ -90,12 +90,12 @@ RSpec.describe Document do
       end
 
       context 'when updating with contents over the limit' do
-        it 'is invalid' do
+        it 'raises an error on save' do
           document = create(:document, contents: small_contents)
           document.contents = large_contents
+          document.original_contents = JSON.generate(large_contents)
 
-          expect(document.valid?).to be(false)
-          expect(document.errors.messages[:contents].first).to match(/is too large/)
+          expect { document.save! }.to raise_error(Document::OverSizeLimit, /is too large/)
         end
       end
 
@@ -119,7 +119,7 @@ RSpec.describe Document do
       context 'when a rejected edit to a large document preserves original state' do
         it 'keeps the document in its pre-edit state after failed save' do
           # Create a document with large contents by bypassing validations
-          original_large_contents = { 'data' => 'x' * (Document::MAX_CONTENTS_SIZE + 1000) }
+          original_large_contents = { 'data' => 'x' * (Document::MAX_CONTENTS_SIZE_BYTES + 1000) }
           document = create(:document, contents: small_contents)
           document.update_column(:contents, original_large_contents)
 
@@ -127,11 +127,11 @@ RSpec.describe Document do
           reloaded = Document.find(document.id)
 
           # Try to edit the large document (should fail)
-          new_large_contents = { 'data' => 'y' * (Document::MAX_CONTENTS_SIZE + 2000) }
+          new_large_contents = { 'data' => 'y' * (Document::MAX_CONTENTS_SIZE_BYTES + 2000) }
           reloaded.contents = new_large_contents
+          reloaded.original_contents = JSON.generate(new_large_contents)
 
-          expect(reloaded.save).to be(false)
-          expect(reloaded.errors.messages[:contents].first).to match(/is too large/)
+          expect { reloaded.save! }.to raise_error(Document::OverSizeLimit, /is too large/)
 
           # Verify the document still has its original contents in the database
           reloaded.reload

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -74,5 +74,71 @@ RSpec.describe Document do
         expect(document.errors.messages).to eq({})
       end
     end
+
+    context 'document size limits' do
+      let(:small_contents) { { 'data' => 'small' } }
+      let(:large_contents) { { 'data' => 'x' * (Document::MAX_CONTENTS_SIZE + 1000) } }
+      let(:schema) { nil }
+
+      context 'when contents are under the limit' do
+        let(:contents) { small_contents }
+
+        it 'is valid' do
+          expect(document.valid?).to be(true)
+          expect(document.errors.messages).to eq({})
+        end
+      end
+
+      context 'when updating with contents over the limit' do
+        it 'is invalid' do
+          document = create(:document, contents: small_contents)
+          document.contents = large_contents
+
+          expect(document.valid?).to be(false)
+          expect(document.errors.messages[:contents].first).to match(/is too large/)
+        end
+      end
+
+      context 'when an existing large document is not modified' do
+        it 'remains valid' do
+          # Create a document with large contents by bypassing validations
+          document = create(:document, contents: small_contents)
+          document.update_column(:contents, large_contents)
+
+          # Reload and verify it can be loaded
+          reloaded = Document.find(document.id)
+          expect(reloaded).to be_present
+          expect(reloaded.contents).to eq(large_contents)
+
+          # Should be valid when not changing contents
+          reloaded.title = 'Updated title'
+          expect(reloaded.valid?).to be(true)
+        end
+      end
+
+      context 'when a rejected edit to a large document preserves original state' do
+        it 'keeps the document in its pre-edit state after failed save' do
+          # Create a document with large contents by bypassing validations
+          original_large_contents = { 'data' => 'x' * (Document::MAX_CONTENTS_SIZE + 1000) }
+          document = create(:document, contents: small_contents)
+          document.update_column(:contents, original_large_contents)
+
+          # Reload the document
+          reloaded = Document.find(document.id)
+
+          # Try to edit the large document (should fail)
+          new_large_contents = { 'data' => 'y' * (Document::MAX_CONTENTS_SIZE + 2000) }
+          reloaded.contents = new_large_contents
+
+          expect(reloaded.save).to be(false)
+          expect(reloaded.errors.messages[:contents].first).to match(/is too large/)
+
+          # Verify the document still has its original contents in the database
+          reloaded.reload
+          expect(reloaded.contents).to eq(original_large_contents)
+          expect(reloaded).to be_valid
+        end
+      end
+    end
   end
 end

--- a/src/pages/DocumentPage.js
+++ b/src/pages/DocumentPage.js
@@ -146,16 +146,13 @@ class DocumentPage extends Component {
     )
   }
   get currentDocumentSizeInBytes() {
-    if (!this.state.contents) return 0
-    const jsonString = JSON.stringify(this.state.contents)
+    if (!this.state.originalContents) return 0
     // Use TextEncoder to match Ruby's .bytesize (UTF-8 bytes, not UTF-16 code units)
-    return new TextEncoder().encode(jsonString).length
+    return new TextEncoder().encode(this.state.originalContents).length
   }
   get savedDocumentSizeInBytes() {
     if (!this.state.savedOriginalContents) return 0
-    const parsed = JSON.parse(this.state.savedOriginalContents)
-    const jsonString = JSON.stringify(parsed)
-    return new TextEncoder().encode(jsonString).length
+    return new TextEncoder().encode(this.state.savedOriginalContents).length
   }
   get isCurrentDocumentOverSizeLimit() {
     const maxSize = this.state.document.maxContentsSize || 0

--- a/src/pages/DocumentPage.js
+++ b/src/pages/DocumentPage.js
@@ -28,6 +28,7 @@ const CONFIRM_TEXT =
 const INITIAL_STATE = {
   contents: null,
   contentsErrorMessage: '',
+  contentsSizeErrorMessage: '',
   document: {},
   isLoading: false,
   isSaving: false,
@@ -144,15 +145,25 @@ class DocumentPage extends Component {
       this.state.originalSchema === this.state.savedOriginalSchema
     )
   }
-  get documentSizeInBytes() {
+  get currentDocumentSizeInBytes() {
     if (!this.state.contents) return 0
     const jsonString = JSON.stringify(this.state.contents)
     // Use TextEncoder to match Ruby's .bytesize (UTF-8 bytes, not UTF-16 code units)
     return new TextEncoder().encode(jsonString).length
   }
-  get isOverSizeLimit() {
+  get savedDocumentSizeInBytes() {
+    if (!this.state.savedOriginalContents) return 0
+    const parsed = JSON.parse(this.state.savedOriginalContents)
+    const jsonString = JSON.stringify(parsed)
+    return new TextEncoder().encode(jsonString).length
+  }
+  get isCurrentDocumentOverSizeLimit() {
     const maxSize = this.state.document.maxContentsSize || 0
-    return this.documentSizeInBytes > maxSize
+    return this.currentDocumentSizeInBytes > maxSize
+  }
+  get isSavedDocumentOverSizeLimit() {
+    const maxSize = this.state.document.maxContentsSize || 0
+    return this.savedDocumentSizeInBytes > maxSize
   }
 
   // Ace editor is picky and gets upset when we try to kick off a validation job
@@ -175,8 +186,9 @@ class DocumentPage extends Component {
             contentsErrorMessage: errorMessage,
           })
           if (_.isEmpty(errorMessage)) {
+            this.validateSizeLimit()
             this.validateSchemaMatch()
-            if (_.isEmpty(this.state.validationErrorMessage)) {
+            if (_.isEmpty(this.state.validationErrorMessage) && _.isEmpty(this.state.contentsSizeErrorMessage)) {
               this.setState({ showContentsErrorMessage: false })
             }
           }
@@ -212,6 +224,25 @@ class DocumentPage extends Component {
     if (this.state.schemaErrorMessage) {
       this.setState({
         showSchemaErrorMessage: true,
+      })
+    }
+  }
+
+  validateSizeLimit = () => {
+    // Only show error if document is over limit AND has been edited
+    // (if not edited, the header badge already shows it, an it'll block the autoformat button)
+    if (this.isCurrentDocumentOverSizeLimit && !this.hasSaved) {
+      const maxSize = this.state.document.maxContentsSize || 0
+      const currentSize = this.currentDocumentSizeInBytes
+      const maxSizeKB = Math.round(maxSize / 1024)
+      const currentSizeKB = Math.ceil(currentSize / 1024)
+      this.setState({
+        contentsSizeErrorMessage: `Document is too large (${currentSizeKB} KB). Maximum size is ${maxSizeKB} KB.`,
+        showContentsErrorMessage: true,
+      })
+    } else {
+      this.setState({
+        contentsSizeErrorMessage: null,
       })
     }
   }
@@ -288,6 +319,7 @@ class DocumentPage extends Component {
   saveDocument = extraParams => {
     if (
       this.state.contentsErrorMessage ||
+      this.state.contentsSizeErrorMessage ||
       this.state.schemaErrorMessage ||
       this.state.validationErrorMessage
     ) {
@@ -318,6 +350,13 @@ class DocumentPage extends Component {
         savedOriginalContents: saveState.originalContents,
         savedOriginalSchema: saveState.originalSchema,
       })
+    }).catch(error => {
+      this.setState({ isSaving: false })
+      if (error.response && error.response.data && error.response.data.error) {
+        alert(error.response.data.error)
+      } else {
+        alert('Failed to save document. Please try again.')
+      }
     })
   }
 
@@ -385,6 +424,9 @@ class DocumentPage extends Component {
         (this.state.contentsErrorMessage
           ? 'Syntax error in JSON data'
           : null) ||
+        (this.state.contentsSizeErrorMessage
+          ? 'JSON data is too large'
+          : null) ||
         (this.state.schemaErrorMessage ? 'Syntax error in schema' : null) ||
         (this.state.validationErrorMessage
           ? 'JSON data does not match schema'
@@ -426,10 +468,10 @@ class DocumentPage extends Component {
         <DocumentPageHeader
           contentsEditable={this.contentsEditable}
           document={this.state.document}
-          documentSizeInBytes={this.documentSizeInBytes}
+          documentSizeInBytes={this.savedDocumentSizeInBytes}
           errorMessage={overallErrorMessage}
           hasSaved={this.hasSaved}
-          isOverSizeLimit={this.isOverSizeLimit}
+          isOverSizeLimit={this.isSavedDocumentOverSizeLimit}
           isSavingDocument={this.state.isSaving}
           onClone={this.requestCloneDocument}
           onSaveTitle={this.onSaveTitle}
@@ -500,7 +542,9 @@ class DocumentPage extends Component {
       <div>
         <ContentsEditor
           errorMessage={
-            this.state.contentsErrorMessage || this.state.validationErrorMessage
+            this.state.contentsErrorMessage ||
+            this.state.contentsSizeErrorMessage ||
+            this.state.validationErrorMessage
           }
           canGenerateSchema={!this.state.originalSchema}
           onAutoformatContents={this.autoformatContents}

--- a/src/pages/DocumentPage.js
+++ b/src/pages/DocumentPage.js
@@ -144,6 +144,16 @@ class DocumentPage extends Component {
       this.state.originalSchema === this.state.savedOriginalSchema
     )
   }
+  get documentSizeInBytes() {
+    if (!this.state.contents) return 0
+    const jsonString = JSON.stringify(this.state.contents)
+    // Use TextEncoder to match Ruby's .bytesize (UTF-8 bytes, not UTF-16 code units)
+    return new TextEncoder().encode(jsonString).length
+  }
+  get isOverSizeLimit() {
+    const maxSize = this.state.document.maxContentsSize || 0
+    return this.documentSizeInBytes > maxSize
+  }
 
   // Ace editor is picky and gets upset when we try to kick off a validation job
   // during the content change handler. (Any tiny slowness causes lag and makes the cursor
@@ -416,8 +426,10 @@ class DocumentPage extends Component {
         <DocumentPageHeader
           contentsEditable={this.contentsEditable}
           document={this.state.document}
+          documentSizeInBytes={this.documentSizeInBytes}
           errorMessage={overallErrorMessage}
           hasSaved={this.hasSaved}
+          isOverSizeLimit={this.isOverSizeLimit}
           isSavingDocument={this.state.isSaving}
           onClone={this.requestCloneDocument}
           onSaveTitle={this.onSaveTitle}

--- a/src/pages/DocumentPage/DocumentPageHeader.js
+++ b/src/pages/DocumentPage/DocumentPageHeader.js
@@ -82,7 +82,7 @@ export default class DocumentPageHeader extends Component {
             overlay={
               <div style={{ maxWidth: '300px' }}>
                 <div>
-                  This document is <b>{Math.round(this.props.documentSizeInBytes / 1024)} KB</b> out of a maximum <b>{Math.round((this.props.document.maxContentsSize || 0) / 1024)} KB</b>.
+                  This document is <b>{Math.ceil(this.props.documentSizeInBytes / 1024)} KB</b> out of a maximum <b>{Math.round((this.props.document.maxContentsSize || 0) / 1024)} KB</b>.
                 </div>
                 <br />
                 <div>

--- a/src/pages/DocumentPage/DocumentPageHeader.js
+++ b/src/pages/DocumentPage/DocumentPageHeader.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Tooltip from 'rc-tooltip'
+import { MdReportProblem } from 'react-icons/lib/md'
 import _ from 'lodash'
 
 import Button from '../../components/Button'
@@ -14,8 +15,10 @@ export default class DocumentPageHeader extends Component {
   static propTypes = {
     contentsEditable: PropTypes.bool,
     document: PropTypes.object.isRequired,
+    documentSizeInBytes: PropTypes.number,
     errorMessage: PropTypes.string,
     hasSaved: PropTypes.bool.isRequired,
+    isOverSizeLimit: PropTypes.bool,
     isSavingDocument: PropTypes.bool,
     onClone: PropTypes.func.isRequired,
     onSaveTitle: PropTypes.func.isRequired,
@@ -71,6 +74,36 @@ export default class DocumentPageHeader extends Component {
               <div className="badge dark-gray">Public</div>
             </Tooltip>
           )
+        )}
+        {this.props.document.editable && this.props.isOverSizeLimit && (
+          <Tooltip
+            placement="bottom"
+            trigger={['hover']}
+            overlay={
+              <div style={{ maxWidth: '300px' }}>
+                <div>
+                  This document is <b>{Math.round(this.props.documentSizeInBytes / 1024)} KB</b> out of a maximum <b>{Math.round((this.props.document.maxContentsSize || 0) / 1024)} KB</b>.
+                </div>
+                <br />
+                <div>
+                  It's still online, but further edits won't be saved until the size is below {Math.round((this.props.document.maxContentsSize || 0) / 1024)} KB.
+                </div>
+                <br />
+                <div>
+                  This limit was added in January 2026 in order to keep costs down so the site can stay free.
+                </div>
+                <br/>
+                <div>
+                  More info at <a target="_blank" href="https://www.npoint.io/changelog>" style={{ color: 'white', fontWeight: 'bold' }}>www.npoint.io/changelog</a>.
+                </div>
+              </div>
+            }
+          >
+            <span className="badge danger" style={{ textTransform: '' }}>
+              <MdReportProblem style={{ marginRight: '4px' }} />
+              Over size limit
+            </span>
+          </Tooltip>
         )}
         <div className="flex-spring" />
         {this.props.contentsEditable && this.renderSaveButton()}


### PR DESCRIPTION
Size limit is set to 100KB — need to query the DB, consider what an appropriate limit would be, and email users with active documents over the limit.

This is part of a measure to keep costs manageable. See https://www.npoint.io/changelog for more info, quoted here:

> n:point has happily been running for 7 years now, and still works well. I'm proud of it. It's currently handling about 10M requests/day, helping people all over the world run small apps and prototype.
‎
> However, the costs have started to become significant. Since n:point was built to quickly edit small config files, it doesn't cache as effectively as it could, and doesn't have strict size or rate limits. Over time, some large bins that are frequently accessed have contributed to a high bandwidth & storage cost and the site is now costing $500/mo to run.
‎
> I will consider a paid tier, but don't have the time to build it out at the moment. My priority is keeping the site online and free. So I'm updating the site to add usage limits and better caching. Thanks for understanding!

How it works:

- Existing documents are still served as-is. The header is updated with a warning (ignore the 30KB, that's for testing):

<img width="522" height="285" alt="image" src="https://github.com/user-attachments/assets/17769948-8d8b-4944-b64d-c101959124a4" />


- New updates over `MAX_CONTENTS_SIZE_BYTES` are rejected
- The frontend shows an error as you edit a large document, and saving is disabled

<img width="666" height="263" alt="image" src="https://github.com/user-attachments/assets/7284630b-c866-405c-b870-3f192667d6f1" />
